### PR TITLE
Remove unused `ReceiveMessage` in Chat example

### DIFF
--- a/examples/Chat.elm
+++ b/examples/Chat.elm
@@ -35,8 +35,7 @@ socketServer = "ws://phoenixchat.herokuapp.com/ws"
 
 
 type Msg
-  = ReceiveMessage String
-  | SendMessage
+  = SendMessage
   | SetNewMessage String
   | PhoenixMsg (Phoenix.Socket.Msg Msg)
   | ReceiveChatMessage JE.Value
@@ -101,11 +100,6 @@ userParams =
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
   case msg of
-    ReceiveMessage str ->
-      ( { model | messages = str :: model.messages }
-      , Cmd.none
-      )
-
     PhoenixMsg msg ->
       let
         ( phxSocket, phxCmd ) = Phoenix.Socket.update msg model.phxSocket


### PR DESCRIPTION
This message appears to have been superseded by `ReceiveChatMessage`. There are no instances of use aside from the declaration and case statement in `update`. I tested that the example compiles and works without it. 

Removing it might help avoid confusion for folks reading the example.

Thanks for this great project!