### PR TITLE
Add Socket.map function

### DIFF
--- a/src/Phoenix/Socket.elm
+++ b/src/Phoenix/Socket.elm
@@ -67,6 +67,22 @@ init path =
   }
 
 
+{-| Maps a Socket to (Socket, Cmd) function over a (Socket, Cmd), combining both Cmds
+-}
+map : (Socket msg -> ( Socket msg, Cmd (Msg msg) ))
+    -> ( Socket msg, Cmd (Msg msg) )
+    -> ( Socket msg, Cmd (Msg msg) )
+map f scktCmd =
+    let
+        ( socket, cmd ) =
+            scktCmd
+
+        ( resultSocket, cmd2 ) =
+            f socket
+    in
+        ( resultSocket, Cmd.batch ([ cmd, cmd2 ]) )
+
+
 {-| -}
 update : Msg msg -> Socket msg -> ( Socket msg, Cmd (Msg msg) )
 update msg socket =


### PR DESCRIPTION
I've been writing my first phoenix + elm application and I was having trouble to initialise my application when joining to multiple channels. With this map function I can now initialise my app like this:

```
socket
  |> joinFirstChannel
  |> Socket.map joinSecondChannel
  |> ...
```

where `joinFirstChannel` and `joinSecondChannel` are both `Socket -> (Socket, Cmd)` functions.

Do you think this is worth merging?

Thanks for the library, it is great!
