### PR TITLE
Use onJoinError for channel join errors

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.1",
+    "version": "2.0.2",
     "summary": "Pure Elm state manager for Phoenix channels",
     "repository": "https://github.com/fbonetti/elm-phoenix-socket.git",
     "license": "MIT",

--- a/src/Phoenix/Socket.elm
+++ b/src/Phoenix/Socket.elm
@@ -171,7 +171,7 @@ joinChannel : Channel msg -> Socket msg -> ( Socket msg, Cmd (Msg msg) )
 joinChannel channel socket =
     let
         push_ =
-            Push "phx_join" channel.name channel.payload channel.onJoin channel.onError
+            Push "phx_join" channel.name channel.payload channel.onJoin channel.onJoinError
 
         channel_ =
             { channel | state = Channel.Joining, joinRef = socket.ref }


### PR DESCRIPTION
- Stores onJoinError in a Push's onError field for joinChannel pushes